### PR TITLE
Refresh timesheet PWA with liquid glass aesthetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# testing-new-app
+# BuildRight Liquid Glass Timesheets
+
+BuildRight Liquid Glass Timesheets is a lightweight progressive web app (PWA) tailored for construction crews. Capture time by project, keep a living roster of your field team, and export polished CSVs for payroll or client billing—all without leaving the browser.
+
+## Highlights
+
+- 💎 Liquid Glass UI inspired by the latest iOS design language, complete with frosted panels and a floating tab bar.
+- 💼 Maintain an always-ready crew list and job board with quick add/remove actions.
+- 🕒 Log daily hours with tasks, notes, and billable status in a mobile-friendly card interface.
+- 🔍 Filter the log by teammate, project, billable status, or date range and see results update instantly.
+- 📤 Export CSV summaries for payroll or clients that respect your current filters.
+- 📱 Works offline and can be installed like an app thanks to the included manifest and service worker.
+- 🔒 All data is stored locally in the browser via `localStorage`, making it ideal for tablets on the job site.
+
+## Getting started
+
+1. Serve the folder with any static file server (for example `python -m http.server`) and open `index.html` in a modern browser (Chrome, Edge, Safari, Firefox).
+2. Visit the **Crew** and **Projects** tabs to enter your team and job information.
+3. Switch to **Daily log** to record hours. The date defaults to today for quick entry.
+4. Use the filter card to focus on a specific person, project, billable status, or date range.
+5. Open the **Reports** tab to review totals and export payroll or client CSV files.
+
+To install the app on desktop or mobile, tap **Add to Home Screen** in the header when prompted. The app will keep working offline after the first successful load.
+
+## Development notes
+
+- The interface is built with vanilla HTML, CSS, and JavaScript—no build step required.
+- Static assets are precached by the service worker using a "cache with network update" pattern.
+- Clearing the site data in your browser resets the application to a clean slate.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,547 @@
+const STORAGE_KEY = 'buildright-timesheets';
+const state = loadState();
+
+const navButtons = document.querySelectorAll('[data-route]');
+const routes = document.querySelectorAll('[data-section]');
+const entryForm = document.querySelector('#entryForm');
+const filterForm = document.querySelector('#filterForm');
+const employeeForm = document.querySelector('#employeeForm');
+const projectForm = document.querySelector('#projectForm');
+const entrySubmitButton = entryForm.querySelector('button[type="submit"]');
+const entryList = document.querySelector('#entryList');
+const entryEmptyState = document.querySelector('#entryEmptyState');
+const employeeList = document.querySelector('#employeeList');
+const projectList = document.querySelector('#projectList');
+const totalHoursEl = document.querySelector('#totalHours');
+const projectCountEl = document.querySelector('#projectCount');
+const employeeCountEl = document.querySelector('#employeeCount');
+const reportEntryCountEl = document.querySelector('#reportEntryCount');
+const reportHourTotalEl = document.querySelector('#reportHourTotal');
+const reportBillableEl = document.querySelector('#reportBillable');
+const exportPayrollBtn = document.querySelector('#exportPayroll');
+const exportClientBtn = document.querySelector('#exportClient');
+const installButton = document.querySelector('#installButton');
+
+init();
+
+function init() {
+  installButton.disabled = true;
+  entryForm.date.value = today();
+  syncSelectOptions();
+  renderEmployees();
+  renderProjects();
+  renderEntries();
+  updateSummary();
+  registerEvents();
+  registerServiceWorker();
+  setupInstallPrompt();
+}
+
+function registerEvents() {
+  navButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.route;
+      navButtons.forEach(btn => btn.classList.toggle('active', btn === button));
+      routes.forEach(section => {
+        section.classList.toggle('active', section.dataset.section === target);
+      });
+    });
+  });
+
+  entryForm.addEventListener('submit', event => {
+    event.preventDefault();
+    const formData = new FormData(entryForm);
+    const entry = {
+      id: randomId(),
+      date: formData.get('date'),
+      employeeId: formData.get('employeeId'),
+      projectId: formData.get('projectId'),
+      hours: Math.max(0, parseFloat(formData.get('hours')) || 0),
+      task: formData.get('task').trim(),
+      notes: formData.get('notes').trim(),
+      billable: entryForm.billable.checked
+    };
+
+    if (!entry.date || !entry.employeeId || !entry.projectId || entry.hours <= 0) {
+      return;
+    }
+
+    state.entries.push(entry);
+    saveState();
+    entryForm.reset();
+    entryForm.date.value = today();
+    entryForm.billable.checked = entry.billable;
+    syncSelectOptions();
+    entryForm.employeeId.value = entry.employeeId;
+    entryForm.projectId.value = entry.projectId;
+    renderEntries();
+    updateSummary();
+  });
+
+  filterForm.addEventListener('input', () => {
+    renderEntries();
+  });
+
+  filterForm.addEventListener('reset', () => {
+    window.requestAnimationFrame(() => {
+      renderEntries();
+    });
+  });
+
+  employeeForm.addEventListener('submit', event => {
+    event.preventDefault();
+    const formData = new FormData(employeeForm);
+    const employee = {
+      id: randomId(),
+      name: formData.get('name').trim(),
+      role: formData.get('role').trim()
+    };
+
+    if (!employee.name) return;
+
+    state.employees.push(employee);
+    saveState();
+    employeeForm.reset();
+    renderEmployees();
+    syncSelectOptions();
+    updateSummary();
+  });
+
+  projectForm.addEventListener('submit', event => {
+    event.preventDefault();
+    const formData = new FormData(projectForm);
+    const project = {
+      id: randomId(),
+      name: formData.get('name').trim(),
+      client: formData.get('client').trim(),
+      location: formData.get('location').trim()
+    };
+
+    if (!project.name) return;
+
+    state.projects.push(project);
+    saveState();
+    projectForm.reset();
+    renderProjects();
+    syncSelectOptions();
+    updateSummary();
+  });
+
+  exportPayrollBtn.addEventListener('click', () => {
+    const entries = getFilteredEntries();
+    if (!entries.length) {
+      alert('No entries match your filters.');
+      return;
+    }
+    const rows = buildPayrollCsv(entries);
+    downloadCsv(rows, `buildright-payroll-${today()}.csv`);
+  });
+
+  exportClientBtn.addEventListener('click', () => {
+    const entries = getFilteredEntries();
+    if (!entries.length) {
+      alert('No entries match your filters.');
+      return;
+    }
+    const rows = buildClientCsv(entries);
+    downloadCsv(rows, `buildright-clients-${today()}.csv`);
+  });
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { employees: [], projects: [], entries: [] };
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      employees: parsed.employees || [],
+      projects: parsed.projects || [],
+      entries: parsed.entries || []
+    };
+  } catch (error) {
+    console.error('Failed to load saved state', error);
+    return { employees: [], projects: [], entries: [] };
+  }
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function syncSelectOptions() {
+  const employeeOptions = buildOptions(state.employees, 'Select crew');
+  setSelectOptions(entryForm.employeeId, employeeOptions);
+  setSelectOptions(filterForm.employeeId, [['', 'All crew'], ...employeeOptions.slice(1)]);
+
+  const projectOptions = buildOptions(state.projects, 'Select project');
+  setSelectOptions(entryForm.projectId, projectOptions);
+  setSelectOptions(filterForm.projectId, [['', 'All projects'], ...projectOptions.slice(1)]);
+
+  const canLog = state.employees.length > 0 && state.projects.length > 0;
+  entryForm.employeeId.disabled = state.employees.length === 0;
+  entryForm.projectId.disabled = state.projects.length === 0;
+  entrySubmitButton.disabled = !canLog;
+}
+
+function buildOptions(items, placeholder) {
+  const rows = [["", placeholder]];
+  for (const item of items) {
+    rows.push([item.id, item.name]);
+  }
+  return rows;
+}
+
+function setSelectOptions(select, options) {
+  const current = select.value;
+  select.innerHTML = '';
+  for (const [value, label] of options) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    select.append(option);
+  }
+  if (options.some(([value]) => value === current)) {
+    select.value = current;
+  }
+}
+
+function renderEmployees() {
+  employeeList.innerHTML = '';
+  if (!state.employees.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-row';
+    const text = document.createElement('span');
+    text.className = 'hint';
+    text.textContent = 'No crew yet. Add your first teammate above.';
+    empty.append(text);
+    employeeList.append(empty);
+    return;
+  }
+
+  for (const employee of state.employees) {
+    const li = document.createElement('li');
+    const info = document.createElement('div');
+    info.className = 'info';
+    const name = document.createElement('strong');
+    name.textContent = employee.name;
+    const role = document.createElement('span');
+    role.textContent = employee.role || 'Role not set';
+    info.append(name, role);
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.textContent = 'Remove';
+    remove.addEventListener('click', () => removeEmployee(employee.id));
+
+    li.append(info, remove);
+    employeeList.append(li);
+  }
+}
+
+function renderProjects() {
+  projectList.innerHTML = '';
+  if (!state.projects.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-row';
+    const text = document.createElement('span');
+    text.className = 'hint';
+    text.textContent = 'No projects yet. Log your jobs above to schedule hours.';
+    empty.append(text);
+    projectList.append(empty);
+    return;
+  }
+
+  for (const project of state.projects) {
+    const li = document.createElement('li');
+    const info = document.createElement('div');
+    info.className = 'info';
+    const name = document.createElement('strong');
+    name.textContent = project.name;
+    const details = document.createElement('span');
+    const parts = [project.client, project.location].filter(Boolean);
+    details.textContent = parts.length ? parts.join(' · ') : 'Client & site not set';
+    info.append(name, details);
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.textContent = 'Remove';
+    remove.addEventListener('click', () => removeProject(project.id));
+
+    li.append(info, remove);
+    projectList.append(li);
+  }
+}
+
+function renderEntries() {
+  const entries = getFilteredEntries();
+  entryList.innerHTML = '';
+
+  if (!entries.length) {
+    entryEmptyState.classList.add('active');
+  } else {
+    entryEmptyState.classList.remove('active');
+  }
+
+  const groups = groupBy(entries, entry => entry.date);
+  const fragment = document.createDocumentFragment();
+
+  const sortedDates = Array.from(groups.keys()).sort((a, b) => (a > b ? -1 : 1));
+  for (const date of sortedDates) {
+    const section = document.createElement('section');
+    section.className = 'entry-group';
+    const heading = document.createElement('h4');
+    heading.textContent = formatDisplayDate(date);
+    section.append(heading);
+
+    for (const entry of groups.get(date)) {
+      section.append(buildEntryCard(entry));
+    }
+
+    fragment.append(section);
+  }
+
+  entryList.append(fragment);
+  renderReportSummary(entries);
+}
+
+function buildEntryCard(entry) {
+  const card = document.createElement('article');
+  card.className = 'entry-card';
+
+  const header = document.createElement('header');
+  const title = document.createElement('strong');
+  const employee = getEmployee(entry.employeeId);
+  title.textContent = employee ? employee.name : 'Unknown crew';
+  const hours = document.createElement('span');
+  hours.className = 'badge';
+  hours.textContent = `${entry.hours.toFixed(2)} hrs`;
+  header.append(title, hours);
+
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  const project = getProject(entry.projectId);
+  if (project) {
+    meta.append(tag(project.name));
+  }
+  if (entry.task) {
+    meta.append(tag(entry.task));
+  }
+  if (!entry.billable) {
+    const nonBillable = document.createElement('span');
+    nonBillable.className = 'badge non-billable';
+    nonBillable.textContent = 'Non-billable';
+    meta.append(nonBillable);
+  }
+
+  const notes = document.createElement('p');
+  notes.textContent = entry.notes || 'No notes added.';
+  notes.className = 'hint';
+
+  const footer = document.createElement('footer');
+  const remove = document.createElement('button');
+  remove.type = 'button';
+  remove.textContent = 'Delete entry';
+  remove.addEventListener('click', () => removeEntry(entry.id));
+  footer.append(remove);
+
+  card.append(header, meta, notes, footer);
+  return card;
+}
+
+function tag(label) {
+  const span = document.createElement('span');
+  span.className = 'badge';
+  span.textContent = label;
+  return span;
+}
+
+function renderReportSummary(entries) {
+  const totalHours = entries.reduce((sum, entry) => sum + entry.hours, 0);
+  const billableHours = entries.filter(entry => entry.billable).reduce((sum, entry) => sum + entry.hours, 0);
+  reportEntryCountEl.textContent = entries.length.toString();
+  reportHourTotalEl.textContent = totalHours.toFixed(2);
+  reportBillableEl.textContent = billableHours.toFixed(2);
+}
+
+function updateSummary() {
+  const totalHours = state.entries.reduce((sum, entry) => sum + entry.hours, 0);
+  totalHoursEl.textContent = totalHours.toFixed(2);
+  projectCountEl.textContent = state.projects.length.toString();
+  employeeCountEl.textContent = state.employees.length.toString();
+}
+
+function getFilteredEntries() {
+  const formData = new FormData(filterForm);
+  const employeeId = formData.get('employeeId');
+  const projectId = formData.get('projectId');
+  const billable = formData.get('billable');
+  const from = formData.get('from');
+  const to = formData.get('to');
+
+  return state.entries.filter(entry => {
+    if (employeeId && entry.employeeId !== employeeId) return false;
+    if (projectId && entry.projectId !== projectId) return false;
+    if (billable === 'true' && !entry.billable) return false;
+    if (billable === 'false' && entry.billable) return false;
+    if (from && entry.date < from) return false;
+    if (to && entry.date > to) return false;
+    return true;
+  });
+}
+
+function removeEmployee(id) {
+  if (!confirm('Remove crew member and their entries?')) return;
+  state.employees = state.employees.filter(employee => employee.id !== id);
+  state.entries = state.entries.filter(entry => entry.employeeId !== id);
+  saveState();
+  renderEmployees();
+  renderEntries();
+  syncSelectOptions();
+  updateSummary();
+}
+
+function removeProject(id) {
+  if (!confirm('Remove project and related entries?')) return;
+  state.projects = state.projects.filter(project => project.id !== id);
+  state.entries = state.entries.filter(entry => entry.projectId !== id);
+  saveState();
+  renderProjects();
+  renderEntries();
+  syncSelectOptions();
+  updateSummary();
+}
+
+function removeEntry(id) {
+  state.entries = state.entries.filter(entry => entry.id !== id);
+  saveState();
+  renderEntries();
+  updateSummary();
+}
+
+function buildPayrollCsv(entries) {
+  const rows = [['Employee', 'Date', 'Project', 'Hours', 'Billable', 'Task', 'Notes']];
+  for (const entry of entries) {
+    const employee = getEmployee(entry.employeeId);
+    const project = getProject(entry.projectId);
+    rows.push([
+      employee ? employee.name : 'Unknown',
+      entry.date,
+      project ? project.name : 'Unassigned',
+      entry.hours.toFixed(2),
+      entry.billable ? 'Yes' : 'No',
+      entry.task || '',
+      entry.notes || ''
+    ]);
+  }
+  return rows;
+}
+
+function buildClientCsv(entries) {
+  const rows = [['Client', 'Project', 'Date', 'Crew', 'Hours', 'Task', 'Notes']];
+  for (const entry of entries) {
+    const project = getProject(entry.projectId);
+    const employee = getEmployee(entry.employeeId);
+    rows.push([
+      project?.client || '',
+      project ? project.name : 'Unassigned',
+      entry.date,
+      employee ? employee.name : 'Unknown',
+      entry.hours.toFixed(2),
+      entry.task || '',
+      entry.notes || ''
+    ]);
+  }
+  return rows;
+}
+
+function downloadCsv(rows, filename) {
+  const csvContent = rows.map(columns => columns.map(escapeCsv).join(',')).join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function escapeCsv(value) {
+  if (value == null) return '';
+  const stringValue = String(value);
+  if (/[",\n]/.test(stringValue)) {
+    return '"' + stringValue.replace(/"/g, '""') + '"';
+  }
+  return stringValue;
+}
+
+function randomId() {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `id-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getEmployee(id) {
+  return state.employees.find(employee => employee.id === id);
+}
+
+function getProject(id) {
+  return state.projects.find(project => project.id === id);
+}
+
+function groupBy(items, keyFn) {
+  const map = new Map();
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!map.has(key)) {
+      map.set(key, []);
+    }
+    map.get(key).push(item);
+  }
+  return map;
+}
+
+function formatDisplayDate(value) {
+  const date = new Date(value + 'T00:00');
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+  return formatter.format(date);
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function registerServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('./service-worker.js').catch(error => {
+      console.error('Service worker registration failed', error);
+    });
+  }
+}
+
+function setupInstallPrompt() {
+  let deferredPrompt = null;
+  window.addEventListener('beforeinstallprompt', event => {
+    event.preventDefault();
+    deferredPrompt = event;
+    installButton.disabled = false;
+  });
+
+  installButton.addEventListener('click', async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+    if (choice.outcome !== 'accepted') {
+      console.info('Install dismissed');
+    }
+    deferredPrompt = null;
+    installButton.disabled = true;
+  });
+}

--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="1" y2="0">
+      <stop offset="0" stop-color="#0b2c3c" />
+      <stop offset="1" stop-color="#1f7a8c" />
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#bg)" />
+  <g fill="#f8fafc">
+    <path d="M70 184V72h52q22 0 36 12.5T172 116q0 19-13.5 31.5T122 160H98v24zm28-52h22q13 0 20.5-6.5T148 116q0-10-7.5-17T120 92H98z" />
+    <path d="M186 184l-26-56h28l26 56h-28z" opacity="0.75" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#2f6ff7" />
+    <title>BuildRight Liquid Glass Timesheets</title>
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="liquid-field" aria-hidden="true">
+      <div class="liquid-orb orb-one"></div>
+      <div class="liquid-orb orb-two"></div>
+      <div class="liquid-orb orb-three"></div>
+    </div>
+
+    <div class="app-shell">
+      <div class="app-chrome">
+        <div class="status-bar" aria-hidden="true">
+          <span class="status-time">9:41</span>
+          <div class="status-glyphs">
+            <span class="glyph signal"></span>
+            <span class="glyph wifi"></span>
+            <span class="glyph battery"></span>
+          </div>
+        </div>
+
+        <header class="app-header card glass">
+          <div class="brand">
+            <span class="brand-mark" aria-hidden="true">BR</span>
+            <div>
+              <p class="eyebrow">BuildRight Field Suite</p>
+              <h1>Liquid Glass Timesheets</h1>
+              <p class="intro">
+                Track crews, projects, and billable hours with an interface that
+                feels native to the latest iOS.
+              </p>
+            </div>
+          </div>
+          <button id="installButton" class="tint-button" type="button">
+            <span class="dot"></span>
+            Add to Home Screen
+          </button>
+        </header>
+
+        <section class="summary-cards" aria-label="Totals overview">
+          <article class="card glass">
+            <span class="label">Logged hours</span>
+            <strong id="totalHours">0</strong>
+            <span class="hint">Across all entries</span>
+          </article>
+          <article class="card glass">
+            <span class="label">Active projects</span>
+            <strong id="projectCount">0</strong>
+            <span class="hint">Jobs on the go</span>
+          </article>
+          <article class="card glass">
+            <span class="label">Crew members</span>
+            <strong id="employeeCount">0</strong>
+            <span class="hint">Ready to schedule</span>
+          </article>
+        </section>
+
+        <main>
+        <section class="route active" data-section="log">
+          <header class="section-header">
+            <div>
+              <h2>Daily log</h2>
+              <p>Track who worked, where, and what was completed.</p>
+            </div>
+          </header>
+
+          <form id="entryForm" class="card form-grid" autocomplete="off">
+            <h3>Log new hours</h3>
+            <label>
+              <span>Date</span>
+              <input type="date" name="date" required />
+            </label>
+            <label>
+              <span>Team member</span>
+              <select name="employeeId" required>
+                <option value="">Select crew</option>
+              </select>
+            </label>
+            <label>
+              <span>Project</span>
+              <select name="projectId" required>
+                <option value="">Select project</option>
+              </select>
+            </label>
+            <label>
+              <span>Hours</span>
+              <input type="number" name="hours" min="0" step="0.25" required />
+            </label>
+            <label>
+              <span>Task</span>
+              <input type="text" name="task" placeholder="E.g. framing, pour, cleanup" />
+            </label>
+            <label class="full">
+              <span>Notes</span>
+              <textarea name="notes" rows="2" placeholder="Weather, materials, crew notes"></textarea>
+            </label>
+            <label class="switch full">
+              <input type="checkbox" name="billable" checked />
+              <span>Billable work</span>
+            </label>
+            <div class="form-actions full">
+              <button type="submit" class="primary">Save entry</button>
+            </div>
+          </form>
+
+          <section class="card filters" aria-label="Entry filters">
+            <h3>Filter log</h3>
+            <form id="filterForm" class="form-grid compact" autocomplete="off">
+              <label>
+                <span>Team member</span>
+                <select name="employeeId">
+                  <option value="">All crew</option>
+                </select>
+              </label>
+              <label>
+                <span>Project</span>
+                <select name="projectId">
+                  <option value="">All projects</option>
+                </select>
+              </label>
+              <label>
+                <span>Billable</span>
+                <select name="billable">
+                  <option value="">Billable + non-billable</option>
+                  <option value="true">Billable</option>
+                  <option value="false">Non-billable</option>
+                </select>
+              </label>
+              <label>
+                <span>From</span>
+                <input type="date" name="from" />
+              </label>
+              <label>
+                <span>To</span>
+                <input type="date" name="to" />
+              </label>
+              <div class="form-actions full">
+                <button type="reset" class="ghost-button">Reset</button>
+              </div>
+            </form>
+          </section>
+
+          <div id="entryEmptyState" class="empty-state card">
+            <h3>No time logged yet</h3>
+            <p>Start by adding your crew, projects, then create an entry above.</p>
+          </div>
+          <div id="entryList" class="entry-list" aria-live="polite"></div>
+        </section>
+
+        <section class="route" data-section="team">
+          <header class="section-header">
+            <div>
+              <h2>Crew</h2>
+              <p>Keep an up-to-date roster of everyone on site.</p>
+            </div>
+          </header>
+          <form id="employeeForm" class="card form-grid" autocomplete="off">
+            <h3>Add crew member</h3>
+            <label>
+              <span>Name</span>
+              <input type="text" name="name" required />
+            </label>
+            <label>
+              <span>Role</span>
+              <input type="text" name="role" placeholder="Foreman, carpenter, laborer" />
+            </label>
+            <div class="form-actions full">
+              <button type="submit" class="primary">Add crew</button>
+            </div>
+          </form>
+          <ul id="employeeList" class="stack-list card"></ul>
+        </section>
+
+        <section class="route" data-section="projects">
+          <header class="section-header">
+            <div>
+              <h2>Projects</h2>
+              <p>Capture job details for hours to roll into.</p>
+            </div>
+          </header>
+          <form id="projectForm" class="card form-grid" autocomplete="off">
+            <h3>Add project</h3>
+            <label>
+              <span>Project name</span>
+              <input type="text" name="name" required />
+            </label>
+            <label>
+              <span>Client</span>
+              <input type="text" name="client" placeholder="Customer or GC" />
+            </label>
+            <label>
+              <span>Location</span>
+              <input type="text" name="location" placeholder="Job site" />
+            </label>
+            <div class="form-actions full">
+              <button type="submit" class="primary">Add project</button>
+            </div>
+          </form>
+          <ul id="projectList" class="stack-list card"></ul>
+        </section>
+
+        <section class="route" data-section="reports">
+          <header class="section-header">
+            <div>
+              <h2>Reports &amp; exports</h2>
+              <p>Use your current filters to pull payroll or client CSVs.</p>
+            </div>
+          </header>
+          <div class="card report-summary">
+            <h3>Filtered totals</h3>
+            <dl>
+              <div>
+                <dt>Entries</dt>
+                <dd id="reportEntryCount">0</dd>
+              </div>
+              <div>
+                <dt>Hours</dt>
+                <dd id="reportHourTotal">0</dd>
+              </div>
+              <div>
+                <dt>Billable hours</dt>
+                <dd id="reportBillable">0</dd>
+              </div>
+            </dl>
+            <p class="hint">Adjust filters on the Daily log to refine this view.</p>
+          </div>
+          <div class="card report-actions">
+            <h3>Export</h3>
+            <p>Downloads respect the filters you have set.</p>
+            <div class="button-row">
+              <button id="exportPayroll" class="primary" type="button">Payroll CSV</button>
+              <button id="exportClient" type="button">Client CSV</button>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <nav class="tab-bar glass" aria-label="Primary">
+        <button class="active" type="button" data-route="log">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <rect x="3.5" y="5.5" width="17" height="15" rx="4" ry="4" />
+            <path d="M3.5 10.5h17" />
+            <path d="M8 3.5v4" />
+            <path d="M16 3.5v4" />
+          </svg>
+          <span>Daily log</span>
+        </button>
+        <button type="button" data-route="team">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="8" cy="9" r="3" />
+            <circle cx="16" cy="11" r="2.5" />
+            <path d="M4.5 19c.2-3 2.5-4 3.5-4s3.3 1.2 3.5 4" />
+            <path d="M13.5 18.5c.4-2 1.8-3 3.5-3 1.3 0 2.5.6 3 1.6" />
+          </svg>
+          <span>Crew</span>
+        </button>
+        <button type="button" data-route="projects">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M5 4.5h9l5 5v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-13a2 2 0 0 1 2-2Z" />
+            <path d="M14 4.5v5h5" />
+            <path d="M8.5 13.5h7" />
+            <path d="M8.5 17.5h7" />
+          </svg>
+          <span>Projects</span>
+        </button>
+        <button type="button" data-route="reports">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M4 20h16" />
+            <rect x="6.2" y="11" width="2.6" height="6" rx="1.2" />
+            <rect x="10.7" y="8.5" width="2.6" height="8.5" rx="1.2" />
+            <rect x="15.2" y="6" width="2.6" height="11" rx="1.2" />
+          </svg>
+          <span>Reports</span>
+        </button>
+      </nav>
+    </div>
+  </div>
+
+    <script src="./app.js" type="module"></script>
+  </body>
+</html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "BuildRight Liquid Glass Timesheets",
+  "short_name": "BuildRight",
+  "description": "An iOS-inspired, offline-ready construction timesheet PWA with crew, project, and export tooling.",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#020617",
+  "theme_color": "#2f6ff7",
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,35 @@
+const CACHE_NAME = 'buildright-timesheets-v3';
+const ASSETS = [
+  'index.html',
+  'styles.css',
+  'app.js',
+  'manifest.webmanifest',
+  'icons/icon.svg'
+].map(path => new URL(path, self.location).pathname);
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached =>
+      cached || fetch(event.request).then(response => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        return response;
+      }).catch(() => cached)
+    )
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,883 @@
+:root {
+  color-scheme: light;
+  font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  --ink-strong: #06121f;
+  --ink-subtle: rgba(6, 18, 31, 0.64);
+  --ink-soft: rgba(6, 18, 31, 0.44);
+  --glass-border: rgba(255, 255, 255, 0.45);
+  --glass-border-strong: rgba(255, 255, 255, 0.62);
+  --glass-fill: rgba(255, 255, 255, 0.24);
+  --glass-fill-strong: rgba(255, 255, 255, 0.34);
+  --surface-shadow: rgba(8, 20, 42, 0.45);
+  --tint-primary: #2f6ff7;
+  --tint-secondary: #62e8ff;
+  --accent-amber: #fbbf24;
+  --accent-green: #22c55e;
+  --radius-large: clamp(20px, 4vw, 36px);
+  --radius-medium: clamp(16px, 3vw, 26px);
+  --radius-small: 14px;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(120% 120% at 20% 18%, rgba(120, 198, 255, 0.55) 0%, rgba(44, 69, 255, 0.42) 28%, rgba(5, 9, 21, 0.95) 100%),
+    radial-gradient(90% 120% at 80% 0%, rgba(255, 149, 241, 0.32) 0%, rgba(6, 12, 29, 0.92) 55%, #020617 100%);
+  color: var(--ink-strong);
+  display: flex;
+  justify-content: center;
+  padding: clamp(1.2rem, 4vw, 3.5rem) clamp(0.75rem, 4vw, 3rem);
+  position: relative;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+.liquid-field {
+  position: fixed;
+  inset: -25% -20% -10%;
+  pointer-events: none;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.liquid-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0px);
+  mix-blend-mode: screen;
+  opacity: 0.55;
+}
+
+.orb-one {
+  width: 48vw;
+  aspect-ratio: 1;
+  background: radial-gradient(circle at 30% 30%, rgba(108, 219, 255, 0.9), rgba(47, 111, 247, 0.25) 65%, transparent 90%);
+  top: -12vw;
+  left: -8vw;
+  animation: floatOne 18s ease-in-out infinite;
+}
+
+.orb-two {
+  width: 38vw;
+  aspect-ratio: 1;
+  background: radial-gradient(circle at 70% 30%, rgba(255, 149, 241, 0.8), rgba(122, 54, 255, 0.25) 60%, transparent 95%);
+  right: -12vw;
+  top: 25vh;
+  animation: floatTwo 22s ease-in-out infinite;
+}
+
+.orb-three {
+  width: 55vw;
+  aspect-ratio: 1;
+  background: radial-gradient(circle at 40% 60%, rgba(94, 232, 255, 0.7), rgba(47, 111, 247, 0.18) 55%, transparent 90%);
+  bottom: -25vh;
+  left: 45vw;
+  animation: floatThree 26s ease-in-out infinite;
+}
+
+@keyframes floatOne {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(3vw, 4vh, 0) scale(1.08);
+  }
+}
+
+@keyframes floatTwo {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.05);
+  }
+  45% {
+    transform: translate3d(-4vw, -3vh, 0) scale(0.95);
+  }
+}
+
+@keyframes floatThree {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  60% {
+    transform: translate3d(-3vw, 5vh, 0) scale(1.1);
+  }
+}
+
+.app-shell {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.app-chrome {
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  background: var(--glass-fill);
+  backdrop-filter: blur(30px) saturate(160%);
+  -webkit-backdrop-filter: blur(30px) saturate(160%);
+  border-radius: var(--radius-large);
+  border: 1px solid var(--glass-border);
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  box-shadow: 0 48px 120px rgba(6, 20, 44, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+  position: relative;
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  padding: 0 0.2rem;
+}
+
+.status-time {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.status-glyphs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.glyph {
+  color: rgba(6, 18, 31, 0.6);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.glyph.signal::before {
+  content: "";
+  display: block;
+  width: 1.1rem;
+  height: 0.85rem;
+  background:
+    linear-gradient(0deg, currentColor 62%, transparent 0) 0 100%/0.18rem 0.62rem no-repeat,
+    linear-gradient(0deg, currentColor 78%, transparent 0) 0.28rem 100%/0.18rem 0.75rem no-repeat,
+    linear-gradient(0deg, currentColor 90%, transparent 0) 0.56rem 100%/0.18rem 0.9rem no-repeat,
+    linear-gradient(0deg, currentColor 100%, transparent 0) 0.84rem 100%/0.18rem 1.05rem no-repeat;
+  opacity: 0.9;
+}
+
+.glyph.wifi {
+  position: relative;
+  width: 1.25rem;
+  height: 0.95rem;
+}
+
+.glyph.wifi::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 2px solid currentColor;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  transform: translateY(-0.08rem);
+  opacity: 0.8;
+}
+
+.glyph.wifi::after {
+  content: "";
+  position: absolute;
+  bottom: -0.05rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0.3rem;
+  height: 0.3rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.9;
+}
+
+.glyph.battery {
+  position: relative;
+  width: 1.7rem;
+  height: 0.95rem;
+  border: 2px solid currentColor;
+  border-radius: 0.3rem;
+}
+
+.glyph.battery::before {
+  content: "";
+  position: absolute;
+  inset: 0.16rem 0.18rem;
+  border-radius: 0.22rem;
+  background: linear-gradient(120deg, rgba(47, 111, 247, 0.65), rgba(98, 232, 255, 0.85));
+}
+
+.glyph.battery::after {
+  content: "";
+  position: absolute;
+  right: -0.32rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0.24rem;
+  height: 0.44rem;
+  border-radius: 0.16rem;
+  background: currentColor;
+}
+
+.card {
+  border-radius: var(--radius-medium);
+  padding: clamp(1.1rem, 3vw, 1.8rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.glass {
+  background: var(--glass-fill-strong);
+  border: 1px solid var(--glass-border-strong);
+  backdrop-filter: blur(24px) saturate(170%);
+  -webkit-backdrop-filter: blur(24px) saturate(170%);
+  box-shadow: 0 24px 60px rgba(6, 22, 46, 0.3);
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1.2rem, 3vw, 2rem);
+}
+
+.brand {
+  display: flex;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  align-items: center;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: clamp(3.1rem, 8vw, 3.6rem);
+  height: clamp(3.1rem, 8vw, 3.6rem);
+  border-radius: 28px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: white;
+  background: linear-gradient(130deg, rgba(47, 111, 247, 0.95), rgba(98, 232, 255, 0.85));
+  box-shadow: 0 20px 30px rgba(47, 111, 247, 0.35);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.72rem;
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.app-header h1 {
+  margin: 0.2rem 0 0.5rem;
+  font-size: clamp(1.75rem, 4vw, 2.35rem);
+  letter-spacing: -0.02em;
+}
+
+.intro {
+  margin: 0;
+  max-width: 32rem;
+  color: var(--ink-subtle);
+  font-size: 0.98rem;
+}
+
+.tint-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.7rem 1.35rem;
+  background: linear-gradient(130deg, rgba(47, 111, 247, 0.95), rgba(98, 232, 255, 0.9));
+  color: white;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 20px 35px rgba(47, 111, 247, 0.35);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tint-button .dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.65);
+}
+
+.tint-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 25px 45px rgba(47, 111, 247, 0.4);
+}
+
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1rem, 3vw, 1.5rem);
+  padding-bottom: 0.25rem;
+}
+
+.summary-cards .card {
+  display: grid;
+  gap: 0.4rem;
+  min-height: 150px;
+  scroll-snap-align: start;
+}
+
+.summary-cards .card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.45), transparent 60%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.summary-cards .label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-soft);
+}
+
+.summary-cards strong {
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  font-weight: 700;
+  margin: 0.2rem 0;
+  background: linear-gradient(135deg, rgba(6, 18, 31, 0.95), rgba(6, 18, 31, 0.6));
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.summary-cards .hint {
+  color: var(--ink-subtle);
+  font-size: 0.9rem;
+  max-width: 18ch;
+}
+
+main {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.route {
+  display: none;
+  flex-direction: column;
+  gap: clamp(1.4rem, 3vw, 2rem);
+}
+
+.route.active {
+  display: flex;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0 0.35rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(1.45rem, 3vw, 1.85rem);
+  letter-spacing: -0.01em;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--ink-subtle);
+  max-width: 36ch;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+}
+
+.form-grid span {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  border-radius: var(--radius-small);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.6));
+  padding: 0.75rem 0.85rem;
+  font: inherit;
+  color: var(--ink-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 12px 26px rgba(8, 26, 52, 0.12);
+  appearance: none;
+}
+
+.form-grid select {
+  background-image: linear-gradient(135deg, rgba(47, 111, 247, 0.15), rgba(98, 232, 255, 0.25));
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+}
+
+.form-grid textarea {
+  resize: vertical;
+  min-height: 90px;
+}
+
+.form-grid input::placeholder,
+.form-grid textarea::placeholder {
+  color: rgba(6, 18, 31, 0.35);
+}
+
+.form-grid input:focus,
+.form-grid select:focus,
+.form-grid textarea:focus {
+  outline: 3px solid rgba(47, 111, 247, 0.35);
+  border-color: rgba(47, 111, 247, 0.65);
+  box-shadow: 0 0 0 4px rgba(98, 232, 255, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.form-grid .full {
+  grid-column: 1 / -1;
+}
+
+.switch {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.switch input {
+  width: 2.8rem;
+  height: 1.5rem;
+  appearance: none;
+  background: rgba(6, 18, 31, 0.12);
+  border-radius: 999px;
+  position: relative;
+  transition: background 0.2s ease;
+  border: 1px solid rgba(6, 18, 31, 0.15);
+}
+
+.switch input::after {
+  content: "";
+  position: absolute;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: white;
+  top: 0.14rem;
+  left: 0.16rem;
+  box-shadow: 0 6px 14px rgba(8, 24, 44, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked {
+  background: linear-gradient(130deg, rgba(47, 111, 247, 0.85), rgba(98, 232, 255, 0.9));
+  border-color: transparent;
+}
+
+.switch input:checked::after {
+  transform: translateX(1.15rem);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.primary {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.6rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: linear-gradient(135deg, rgba(47, 111, 247, 0.95), rgba(98, 232, 255, 0.92));
+  color: white;
+  cursor: pointer;
+  box-shadow: 0 18px 30px rgba(47, 111, 247, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 38px rgba(47, 111, 247, 0.4);
+}
+
+.ghost-button {
+  border-radius: 999px;
+  border: 1px solid rgba(6, 18, 31, 0.16);
+  background: rgba(255, 255, 255, 0.3);
+  color: var(--ink-strong);
+  padding: 0.7rem 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(8, 26, 52, 0.12);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ghost-button:hover {
+  border-color: rgba(47, 111, 247, 0.45);
+  box-shadow: 0 16px 28px rgba(47, 111, 247, 0.18);
+}
+
+.filters.compact .form-actions {
+  justify-content: flex-end;
+}
+
+.entry-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.entry-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.entry-group h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.01em;
+}
+
+.entry-card {
+  border-radius: var(--radius-medium);
+  padding: 1.1rem 1.2rem 1.2rem;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 14px 34px rgba(8, 26, 52, 0.16);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.entry-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.entry-card header strong {
+  font-size: 1.05rem;
+}
+
+.entry-card .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--ink-subtle);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(47, 111, 247, 0.18);
+  color: rgba(47, 111, 247, 0.95);
+}
+
+.badge.non-billable {
+  background: rgba(239, 68, 68, 0.15);
+  color: rgba(185, 28, 28, 0.92);
+}
+
+.entry-card footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.entry-card footer button {
+  border: none;
+  background: none;
+  color: rgba(239, 68, 68, 0.85);
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+}
+
+.stack-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.stack-list.card {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.stack-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid rgba(6, 18, 31, 0.08);
+}
+
+.stack-list li:last-child {
+  border-bottom: none;
+}
+
+.stack-list .info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.stack-list .info strong {
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+}
+
+.stack-list .info span {
+  font-size: 0.85rem;
+  color: var(--ink-subtle);
+}
+
+.stack-list button {
+  border: none;
+  background: rgba(239, 68, 68, 0.15);
+  color: rgba(185, 28, 28, 0.9);
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.empty-state {
+  text-align: center;
+  display: none;
+  gap: 0.55rem;
+}
+
+.empty-state.active {
+  display: grid;
+}
+
+.empty-state h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.empty-state p {
+  margin: 0;
+  color: var(--ink-subtle);
+}
+
+.report-summary dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.report-summary dt {
+  font-size: 0.85rem;
+  color: var(--ink-subtle);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.report-summary dd {
+  margin: 0.15rem 0 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.report-actions .button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.tab-bar {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.35rem;
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 25px 55px rgba(6, 22, 46, 0.35);
+  position: sticky;
+  bottom: 0;
+  margin-top: auto;
+  z-index: 5;
+}
+
+.tab-bar button {
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  padding: 0.65rem 0.5rem;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  color: rgba(6, 18, 31, 0.55);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: color 0.25s ease, background 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.tab-bar button svg {
+  width: 1.45rem;
+  height: 1.45rem;
+  transition: transform 0.25s ease;
+}
+
+.tab-bar button svg * {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.tab-bar button.active {
+  background: linear-gradient(135deg, rgba(47, 111, 247, 0.95), rgba(98, 232, 255, 0.9));
+  color: white;
+  box-shadow: 0 16px 30px rgba(47, 111, 247, 0.35);
+  transform: translateY(-2px);
+}
+
+.tab-bar button.active svg {
+  transform: scale(1.1);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid rgba(47, 111, 247, 0.35);
+  outline-offset: 2px;
+}
+
+@media (max-width: 960px) {
+  body {
+    padding: clamp(1rem, 3vw, 2.25rem);
+  }
+
+  .app-chrome {
+    padding: clamp(1.4rem, 4vw, 2.2rem);
+    border-radius: clamp(22px, 6vw, 32px);
+  }
+
+  .summary-cards {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(240px, 1fr);
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding-bottom: 0.5rem;
+  }
+
+  .summary-cards::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    align-items: stretch;
+  }
+
+  .app-chrome {
+    width: 100%;
+    border-radius: 0;
+    padding: clamp(1.15rem, 3vw, 1.6rem);
+    box-shadow: none;
+    border: none;
+    backdrop-filter: none;
+    background: rgba(255, 255, 255, 0.82);
+  }
+
+  .status-bar {
+    padding-inline: 0.5rem;
+  }
+
+  .app-header {
+    border-radius: 24px;
+  }
+
+  .summary-cards {
+    margin-inline: -0.4rem;
+    padding-inline: 0.4rem;
+  }
+
+  .tab-bar {
+    position: sticky;
+    bottom: 0.75rem;
+    margin-inline: auto;
+    max-width: 420px;
+  }
+}
+
+@media (max-width: 540px) {
+  .brand {
+    align-items: flex-start;
+  }
+
+  .brand-mark {
+    width: 2.8rem;
+    height: 2.8rem;
+    border-radius: 22px;
+  }
+
+  .summary-cards {
+    grid-auto-columns: minmax(210px, 1fr);
+  }
+
+  .form-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .tab-bar {
+    bottom: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the shell with a liquid glass background, faux status bar, and floating tab bar to evoke the latest iOS style
- restyle cards, forms, and navigation with frosted glass gradients, iconography, and updated copy for the Add to Home Screen flow
- align the manifest theme details and service worker cache with the new look and document the refreshed interface in the README

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d753a2261c833288c0e8811c522ae8